### PR TITLE
R8 and AndroidLib consumer that keeps all native methods in ExternalSQLite.

### DIFF
--- a/AndroidLib/proguard-consumer-rules.pro
+++ b/AndroidLib/proguard-consumer-rules.pro
@@ -5,6 +5,7 @@
 # For more details, see
 #   http://developer.android.com/guide/developing/tools/proguard.html
 
--keepclasseswithmembernames,includedescriptorclasses class * {
+# Eagerly loaded in JNI.
+-keep class com.bloomberg.selekt.ExternalSQLite {
     native <methods>;
 }


### PR DESCRIPTION
**Describe your changes**
Configure R8 consumer to keep all native methods that are loaded eagerly on JNI.