### PR TITLE
Kotlin parallel tasks flag was deprecated with 1.5.20.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,5 +14,3 @@ kotlin.code.style=official
 
 android.useAndroidX=true
 android.enableJetifier=true
-
-kotlin.parallel.tasks.in.project=true


### PR DESCRIPTION
ref https://kotlinlang.org/docs/whatsnew1520.html#deprecation-of-the-kotlin-parallel-tasks-in-project-build-property