### PR TITLE
Revert "Android Lint 30.0.0 is now released."

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -22,7 +22,7 @@ enum class Versions(
 ) {
     ANDROID_BUILD_TOOLS("30.0.3", URL("https://developer.android.com/studio/releases/build-tools")),
     ANDROID_GRADLE_PLUGIN("4.2.2", URL("https://developer.android.com/tools/revisions/gradle-plugin.html")),
-    ANDROID_LINT("30.0.0", URL("https://github.com/googlesamples/android-custom-lint-rules")),
+    ANDROID_LINT("30.0.0-alpha07", URL("https://github.com/googlesamples/android-custom-lint-rules")),
     ANDROID_NDK("21.4.7075529", URL("https://developer.android.com/ndk")),
     ANDROID_SDK("30", URL("https://developer.android.com/sdk")),
     ANDROIDX_LIVE_DATA("2.2.0", URL("https://developer.android.com/topic/libraries/architecture/livedata")),


### PR DESCRIPTION
Reverts bloomberg/selekt#182