### PR TITLE
Publish Android benchmarks.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -62,7 +62,7 @@ jobs:
         ./gradlew :jacocoSelektCoverageVerification
     - name: 'Build others'
       run: |
-        ./gradlew :AndroidCLI:assembleDebug :AndroidLint:assemble jmhClasses
+        ./gradlew assembleAndroidTest :AndroidCLI:assembleDebug :AndroidLint:assemble jmhClasses
     - name: 'Tear down'
       if: always()
       run: |

--- a/AndroidLibBenchmark/build.gradle.kts
+++ b/AndroidLibBenchmark/build.gradle.kts
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 Bloomberg Finance L.P.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+buildscript {
+    repositories {
+        google()
+    }
+    dependencies {
+        classpath("androidx.benchmark:benchmark-gradle-plugin:${Versions.ANDROID_BENCHMARK_GRADLE_PLUGIN}")
+    }
+}
+
+plugins {
+    id("com.android.library")
+    id("kotlin-android")
+}
+
+apply {
+    plugin("androidx.benchmark")
+}
+
+repositories {
+    mavenCentral()
+    google()
+}
+
+android {
+    compileSdkVersion(Versions.ANDROID_SDK.version.toInt())
+    buildToolsVersion(Versions.ANDROID_BUILD_TOOLS.version)
+
+    defaultConfig {
+        minSdkVersion(21)
+        targetSdkVersion(30)
+
+        testInstrumentationRunner = "androidx.benchmark.junit4.AndroidBenchmarkRunner"
+        testInstrumentationRunnerArguments.putAll(arrayOf(
+            "androidx.benchmark.suppressErrors" to "EMULATOR,LOW_BATTERY,UNLOCKED"
+        ))
+    }
+
+    arrayOf("androidTest").forEach {
+        sourceSets[it].java.srcDir("src/$it/kotlin")
+    }
+
+    configurations.all {
+        resolutionStrategy {
+            // FIXME Please remove as soon as the project compiles without.
+            force("org.jetbrains.kotlin:kotlin-stdlib:${Versions.KOTLIN}")
+            force("org.jetbrains.kotlin:kotlin-stdlib-common:${Versions.KOTLIN}")
+        }
+    }
+
+    lintOptions {
+        disable("OldTargetApi")
+    }
+}
+
+dependencies {
+    androidTestImplementation(project(":AndroidLib"))
+    androidTestImplementation("junit:junit:${Versions.JUNIT4}")
+    androidTestImplementation("androidx.test:runner:1.4.0")
+    androidTestImplementation("androidx.test:rules:1.4.0")
+    androidTestImplementation("androidx.test.ext:junit:1.1.3")
+    androidTestImplementation(androidX("benchmark", "junit4", "1.0.0"))
+    androidTestImplementation(kotlin("test", Versions.KOTLIN.version))
+    androidTestImplementation(kotlin("test-junit", Versions.KOTLIN.version))
+    androidTestImplementation(kotlinX("coroutines-core", Versions.KOTLIN_COROUTINES.version))
+    androidTestImplementation(kotlinX("coroutines-jdk8", Versions.KOTLIN_COROUTINES.version))
+}

--- a/AndroidLibBenchmark/src/androidTest/AndroidManifest.xml
+++ b/AndroidLibBenchmark/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.bloomberg.selekt.android.benchmark">
+    <!-- Important: disable debuggable for accurate performance results -->
+    <application
+        android:debuggable="false"
+        tools:ignore="HardcodedDebugMode"
+        tools:replace="android:debuggable"/>
+</manifest>

--- a/AndroidLibBenchmark/src/androidTest/kotlin/com/bloomberg/selekt/android/benchmark/SQLiteDatabaseBenchmark.kt
+++ b/AndroidLibBenchmark/src/androidTest/kotlin/com/bloomberg/selekt/android/benchmark/SQLiteDatabaseBenchmark.kt
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2021 Bloomberg Finance L.P.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bloomberg.selekt.android.benchmark
+
+import android.content.ContentValues
+import android.content.Context
+import androidx.benchmark.junit4.BenchmarkRule
+import androidx.benchmark.junit4.measureRepeated
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import com.bloomberg.selekt.SQLiteJournalMode
+import com.bloomberg.selekt.android.ConflictAlgorithm
+import com.bloomberg.selekt.android.ISQLiteOpenHelper
+import com.bloomberg.selekt.android.SQLiteOpenHelper
+import com.bloomberg.selekt.android.SQLiteDatabase
+import com.bloomberg.selekt.android.SQLiteOpenParams
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import java.nio.charset.StandardCharsets
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+private fun createSQLiteOpenHelper(
+    context: Context,
+    journalMode: SQLiteJournalMode
+): ISQLiteOpenHelper = SQLiteOpenHelper(
+    context,
+    ISQLiteOpenHelper.Configuration(
+        callback = SQLiteSupportOpenHelperCallback,
+        key = "a".repeat(32).toByteArray(StandardCharsets.UTF_8),
+        name = "test"
+    ),
+    1,
+    SQLiteOpenParams(journalMode)
+)
+
+private object SQLiteSupportOpenHelperCallback : ISQLiteOpenHelper.Callback {
+    override fun onCreate(database: SQLiteDatabase) = database.exec("CREATE TABLE 'Foo' (bar INT)")
+
+    override fun onUpgrade(database: SQLiteDatabase, oldVersion: Int, newVersion: Int) = Unit
+}
+
+data class Inputs(
+    val description: String,
+    val journalMode: SQLiteJournalMode
+) {
+    override fun toString() = description
+}
+
+@LargeTest
+@RunWith(Parameterized::class)
+internal class SQLiteJournalModeDatabaseBenchmark(inputs: Inputs) {
+    @get:Rule
+    val benchmarkRule = BenchmarkRule()
+
+    private val targetContext: Context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private val databaseHelper = inputs.run { createSQLiteOpenHelper(targetContext, journalMode) }
+
+    companion object {
+        @Parameters(name = "{0}")
+        @JvmStatic
+        fun initParameters(): Iterable<Inputs> = arrayOf(SQLiteJournalMode.DELETE, SQLiteJournalMode.WAL).run {
+            List(size) { this[it].let { mode -> Inputs(mode.name, mode) } }
+        }
+    }
+
+    @After
+    fun tearDown() {
+        databaseHelper.writableDatabase.run {
+            try {
+                close()
+                assertFalse(isOpen)
+            } finally {
+                assertTrue(SQLiteDatabase.deleteDatabase(targetContext.getDatabasePath(databaseHelper.databaseName)))
+            }
+        }
+    }
+
+    @Test
+    fun singleQuery(): Unit = databaseHelper.writableDatabase.run {
+        insert("Foo", ContentValues().apply { put("bar", 42) }, ConflictAlgorithm.REPLACE)
+        benchmarkRule.measureRepeated {
+            query(false, "Foo", null, null, null).use { }
+        }
+    }
+
+    @Test
+    fun insertInt(): Unit = databaseHelper.writableDatabase.run {
+        val arg = Array(1) { 0 }
+        benchmarkRule.measureRepeated {
+            transact {
+                for (i in 1..100) {
+                    arg[0] = i
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (?)", arg)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun insertIntWithOnConflict(): Unit = databaseHelper.writableDatabase.run {
+        val values = ContentValues()
+        benchmarkRule.measureRepeated {
+            transact {
+                for (i in 1..100) {
+                    values.put("bar", i)
+                    insert("Foo", values, ConflictAlgorithm.REPLACE)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun insertIntWithStatement(): Unit = databaseHelper.writableDatabase.run {
+        val statement = compileStatement("INSERT OR REPLACE INTO 'Foo' VALUES (?)")
+        benchmarkRule.measureRepeated {
+            transact {
+                for (i in 1L..100L) {
+                    statement.bindLong(1, i)
+                    statement.executeInsert()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun insertFiveUnboundIntsSequentiallyWithOnConflict(): Unit = databaseHelper.writableDatabase.run {
+        benchmarkRule.measureRepeated {
+            transact {
+                repeat(100) {
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (0)")
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (1)")
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (2)")
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (3)")
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (4)")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun insertTwentyUnboundIntsSequentiallyWithOnConflict(): Unit = databaseHelper.writableDatabase.run {
+        benchmarkRule.measureRepeated {
+            transact {
+                repeat(100) {
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (0)")
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (1)")
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (2)")
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (3)")
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (4)")
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (5)")
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (6)")
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (7)")
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (8)")
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (9)")
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (10)")
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (11)")
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (12)")
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (13)")
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (14)")
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (15)")
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (16)")
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (17)")
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (18)")
+                    exec("INSERT OR REPLACE INTO 'Foo' VALUES (19)")
+                }
+            }
+        }
+    }
+
+    @OptIn(com.bloomberg.selekt.Experimental::class)
+    @Test
+    fun batchInsertInt(): Unit = databaseHelper.writableDatabase.run {
+        val args = Array(1) { 0 }
+        benchmarkRule.measureRepeated {
+            batch("INSERT OR REPLACE INTO 'Foo' VALUES (?)", sequence {
+                for (i in 1..100) {
+                    args[0] = i
+                    yield(args)
+                }
+            })
+        }
+    }
+
+    @Test
+    fun queryAndInsertIntWithOnConflict(): Unit = databaseHelper.writableDatabase.run {
+        val values = ContentValues()
+        transact {
+            for (i in 1..100) {
+                values.put("bar", i)
+                insert("Foo", values, ConflictAlgorithm.REPLACE)
+            }
+        }
+        benchmarkRule.measureRepeated {
+            runBlocking(Dispatchers.IO) {
+                coroutineScope {
+                    launch {
+                        transact {
+                            for (i in 1..100) {
+                                values.put("bar", i)
+                                insert("Foo", values, ConflictAlgorithm.REPLACE)
+                            }
+                        }
+                    }
+                    launch {
+                        query(false, "Foo", emptyArray(), "", emptyArray(), limit = 100)
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun multiQueryAndInsertIntWithOnConflict(): Unit = databaseHelper.writableDatabase.run {
+        val values = ContentValues()
+        transact {
+            for (i in 1..100) {
+                values.put("bar", i)
+                insert("Foo", values, ConflictAlgorithm.REPLACE)
+            }
+        }
+        benchmarkRule.measureRepeated {
+            runBlocking(Dispatchers.IO) {
+                coroutineScope {
+                    launch {
+                        transact {
+                            for (i in 1..100) {
+                                values.put("bar", i)
+                                insert("Foo", values, ConflictAlgorithm.REPLACE)
+                            }
+                        }
+                    }
+                    repeat(4) {
+                        launch {
+                            query(false, "Foo", emptyArray(), "", emptyArray(), limit = 100)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun multiQuery(): Unit = databaseHelper.writableDatabase.run {
+        benchmarkRule.measureRepeated {
+            runBlocking(Dispatchers.IO) {
+                coroutineScope {
+                    repeat(4) {
+                        launch {
+                            query(false, "Foo", emptyArray(), "", emptyArray(), limit = 100)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun queryLargeEntryWhileInsertWithOnConflict(): Unit = databaseHelper.writableDatabase.run {
+        val values = ContentValues().apply { put("bar", "a".repeat(10_000)) }
+        insert("Foo", values, ConflictAlgorithm.REPLACE)
+        benchmarkRule.measureRepeated {
+            runBlocking(Dispatchers.IO) {
+                coroutineScope {
+                    launch {
+                        transact {
+                            for (i in 1..100) {
+                                insert("Foo", values, ConflictAlgorithm.REPLACE)
+                            }
+                        }
+                    }
+                    launch {
+                        query(false, "Foo", emptyArray(), "", emptyArray(), limit = 100)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AndroidLibBenchmark/src/androidTest/kotlin/com/bloomberg/selekt/android/benchmark/SQLiteDatabaseCacheBenchmark.kt
+++ b/AndroidLibBenchmark/src/androidTest/kotlin/com/bloomberg/selekt/android/benchmark/SQLiteDatabaseCacheBenchmark.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2021 Bloomberg Finance L.P.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bloomberg.selekt.android.benchmark
+
+import android.content.ContentValues
+import android.content.Context
+import androidx.benchmark.junit4.BenchmarkRule
+import androidx.benchmark.junit4.measureRepeated
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import com.bloomberg.selekt.SQLiteJournalMode
+import com.bloomberg.selekt.android.ConflictAlgorithm
+import com.bloomberg.selekt.android.ISQLiteOpenHelper
+import com.bloomberg.selekt.android.SQLiteDatabase
+import com.bloomberg.selekt.android.SQLiteOpenHelper
+import com.bloomberg.selekt.android.SQLiteOpenParams
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import java.nio.charset.StandardCharsets
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+private fun createSQLiteOpenHelper(
+    context: Context
+): ISQLiteOpenHelper = SQLiteOpenHelper(
+    context,
+    ISQLiteOpenHelper.Configuration(
+        callback = CacheSQLiteSupportOpenHelperCallback,
+        key = "a".repeat(32).toByteArray(StandardCharsets.UTF_8),
+        name = "test-cache"
+    ),
+    1,
+    SQLiteOpenParams(SQLiteJournalMode.WAL)
+)
+
+private object CacheSQLiteSupportOpenHelperCallback : ISQLiteOpenHelper.Callback {
+    override fun onCreate(database: SQLiteDatabase): Unit = database.run {
+        val values = ContentValues()
+        transact {
+            exec("CREATE TABLE 'Foo' (bar INT)")
+            for (i in 0 until 10_000) {
+                values.put("bar", i)
+                assertTrue(insert("Foo", values, ConflictAlgorithm.REPLACE) > 0)
+            }
+            exec("CREATE INDEX 'FooIndex' ON 'Foo' (bar)")
+        }
+    }
+
+    override fun onUpgrade(database: SQLiteDatabase, oldVersion: Int, newVersion: Int) = Unit
+}
+
+data class CacheInputs(
+    private val description: String,
+    val statements: Iterable<Pair<String, Array<String?>>>
+) {
+    override fun toString() = description
+}
+
+@LargeTest
+@RunWith(Parameterized::class)
+internal class SQLiteDatabaseCacheBenchmark(private val inputs: CacheInputs) {
+    @get:Rule
+    val benchmarkRule = BenchmarkRule()
+
+    private val targetContext: Context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private val databaseHelper = inputs.run { createSQLiteOpenHelper(targetContext) }
+
+    companion object {
+        @Parameters(name = "{0}")
+        @JvmStatic
+        fun initParameters(): Iterable<CacheInputs> = arrayOf(
+            CacheInputs("reuse", Array(10_000) {
+                Pair("SELECT * FROM 'Foo' WHERE bar=?", arrayOf<String?>("$it"))
+            }.asIterable()),
+            CacheInputs("waste", Array(10_000) {
+                Pair("SELECT * FROM 'Foo' WHERE bar=$it", arrayOf<String?>())
+            }.asIterable()
+        )).asIterable()
+    }
+
+    @After
+    fun tearDown() {
+        databaseHelper.writableDatabase.run {
+            try {
+                close()
+                assertFalse(isOpen)
+            } finally {
+                assertTrue(SQLiteDatabase.deleteDatabase(targetContext.getDatabasePath(databaseHelper.databaseName)))
+            }
+        }
+    }
+
+    @Test
+    fun simpleSelectPreparedStatementCache() {
+        benchmarkRule.measureRepeated {
+            databaseHelper.writableDatabase.run {
+                inputs.statements.forEach {
+                    query(it.first, it.second)
+                }
+            }
+        }
+    }
+}

--- a/AndroidLibBenchmark/src/androidTest/kotlin/com/bloomberg/selekt/android/benchmark/SQLiteDatabaseIndexBenchmark.kt
+++ b/AndroidLibBenchmark/src/androidTest/kotlin/com/bloomberg/selekt/android/benchmark/SQLiteDatabaseIndexBenchmark.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2021 Bloomberg Finance L.P.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bloomberg.selekt.android.benchmark
+
+import android.content.ContentValues
+import android.content.Context
+import androidx.benchmark.junit4.BenchmarkRule
+import androidx.benchmark.junit4.measureRepeated
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import com.bloomberg.selekt.SQLiteJournalMode
+import com.bloomberg.selekt.android.ConflictAlgorithm
+import com.bloomberg.selekt.android.ISQLiteOpenHelper
+import com.bloomberg.selekt.android.SQLiteDatabase
+import com.bloomberg.selekt.android.SQLiteOpenHelper
+import com.bloomberg.selekt.android.SQLiteOpenParams
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import java.nio.charset.StandardCharsets
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+private fun createSQLiteOpenHelper(
+    context: Context,
+    inputs: IndexInputs
+): ISQLiteOpenHelper = SQLiteOpenHelper(
+    context,
+    ISQLiteOpenHelper.Configuration(
+        callback = inputs.callback,
+        key = "a".repeat(32).toByteArray(StandardCharsets.UTF_8),
+        name = "test-index"
+    ),
+    1,
+    SQLiteOpenParams(SQLiteJournalMode.WAL)
+)
+
+private open class NoIndexSQLiteSupportOpenHelperCallback : ISQLiteOpenHelper.Callback {
+    override fun onCreate(database: SQLiteDatabase): Unit = database.run {
+        val values = ContentValues()
+        transact {
+            exec("CREATE TABLE 'Foo' (bar INT)")
+            for (i in 0 until 1_000) {
+                values.put("bar", i)
+                assertTrue(insert("Foo", values, ConflictAlgorithm.REPLACE) > 0)
+            }
+        }
+    }
+
+    override fun onUpgrade(database: SQLiteDatabase, oldVersion: Int, newVersion: Int) = Unit
+}
+
+private object IndexSQLiteSupportOpenHelperCallback : NoIndexSQLiteSupportOpenHelperCallback() {
+    override fun onCreate(database: SQLiteDatabase): Unit = database.run {
+        super.onCreate(database)
+        transact {
+            exec("CREATE INDEX 'FooIndex' ON 'Foo' (bar)")
+        }
+    }
+
+    override fun onUpgrade(database: SQLiteDatabase, oldVersion: Int, newVersion: Int) = Unit
+}
+
+data class IndexInputs(
+    private val description: String,
+    val callback: ISQLiteOpenHelper.Callback
+) {
+    override fun toString() = description
+}
+
+@LargeTest
+@RunWith(Parameterized::class)
+internal class SQLiteDatabaseIndexBenchmark(inputs: IndexInputs) {
+    @get:Rule
+    val benchmarkRule = BenchmarkRule()
+
+    private val targetContext: Context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private val databaseHelper = createSQLiteOpenHelper(targetContext, inputs)
+
+    companion object {
+        @Parameters(name = "{0}")
+        @JvmStatic
+        fun initParameters(): Iterable<IndexInputs> = arrayOf(
+            IndexInputs("index", IndexSQLiteSupportOpenHelperCallback),
+            IndexInputs("none", NoIndexSQLiteSupportOpenHelperCallback())
+        ).asIterable()
+    }
+
+    @After
+    fun tearDown() {
+        databaseHelper.writableDatabase.run {
+            try {
+                close()
+                assertFalse(isOpen)
+            } finally {
+                assertTrue(SQLiteDatabase.deleteDatabase(targetContext.getDatabasePath(databaseHelper.databaseName)))
+            }
+        }
+    }
+
+    @Test
+    fun simpleSelect() {
+        val statements = Array(1_000) {
+            Pair("SELECT * FROM 'Foo' WHERE bar=?", arrayOf<String?>("$it"))
+        }
+        benchmarkRule.measureRepeated {
+            databaseHelper.writableDatabase.run {
+                statements.forEach {
+                    query(it.first, it.second)
+                }
+            }
+        }
+    }
+}

--- a/AndroidLibBenchmark/src/androidTest/kotlin/com/bloomberg/selekt/android/benchmark/SQLiteDatabaseTransactedReadBenchmark.kt
+++ b/AndroidLibBenchmark/src/androidTest/kotlin/com/bloomberg/selekt/android/benchmark/SQLiteDatabaseTransactedReadBenchmark.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2021 Bloomberg Finance L.P.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bloomberg.selekt.android.benchmark
+
+import android.content.ContentValues
+import android.content.Context
+import androidx.benchmark.junit4.BenchmarkRule
+import androidx.benchmark.junit4.measureRepeated
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import com.bloomberg.selekt.SQLiteJournalMode
+import com.bloomberg.selekt.android.ConflictAlgorithm
+import com.bloomberg.selekt.android.ISQLiteOpenHelper
+import com.bloomberg.selekt.android.SQLiteDatabase
+import com.bloomberg.selekt.android.SQLiteOpenHelper
+import com.bloomberg.selekt.android.SQLiteOpenParams
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import java.nio.charset.StandardCharsets
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+private fun createSQLiteOpenHelper(
+    context: Context,
+    inputs: ReadTransactionInputs
+): ISQLiteOpenHelper = SQLiteOpenHelper(
+    context,
+    ISQLiteOpenHelper.Configuration(
+        callback = inputs.callback,
+        key = "a".repeat(32).toByteArray(StandardCharsets.UTF_8),
+        name = "test-transactions"
+    ),
+    1,
+    SQLiteOpenParams(SQLiteJournalMode.WAL)
+)
+
+private object ReadSQLiteSupportOpenHelperCallback : ISQLiteOpenHelper.Callback {
+    override fun onCreate(database: SQLiteDatabase): Unit = database.run {
+        val values = ContentValues()
+        transact {
+            exec("CREATE TABLE 'Foo' (bar INT)")
+            for (i in 0 until 1_000) {
+                values.put("bar", i)
+                assertTrue(insert("Foo", values, ConflictAlgorithm.REPLACE) > 0)
+            }
+        }
+    }
+
+    override fun onUpgrade(database: SQLiteDatabase, oldVersion: Int, newVersion: Int) = Unit
+}
+
+data class ReadTransactionInputs(
+    private val description: String,
+    val callback: ISQLiteOpenHelper.Callback,
+    val block: (SQLiteDatabase, Array<Pair<String, Array<String?>>>) -> Unit
+) {
+    override fun toString() = description
+}
+
+@LargeTest
+@RunWith(Parameterized::class)
+internal class SQLiteDatabaseTransactedReadBenchmark(private val inputs: ReadTransactionInputs) {
+    @get:Rule
+    val benchmarkRule = BenchmarkRule()
+
+    private val targetContext: Context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private val databaseHelper = createSQLiteOpenHelper(targetContext, inputs)
+
+    companion object {
+        @Parameters(name = "{0}")
+        @JvmStatic
+        fun initParameters(): Iterable<ReadTransactionInputs> = arrayOf(
+            ReadTransactionInputs("inside", ReadSQLiteSupportOpenHelperCallback) { database, array ->
+                database.transact { // Captures the writable connection.
+                    array.forEach {
+                        database.query(it.first, it.second)
+                    }
+                }
+            },
+            ReadTransactionInputs("outside", ReadSQLiteSupportOpenHelperCallback) { database, array ->
+                array.forEach {
+                    database.query(it.first, it.second)
+                }
+            }
+        ).asIterable()
+    }
+
+    @After
+    fun tearDown() {
+        databaseHelper.writableDatabase.run {
+            try {
+                close()
+                assertFalse(isOpen)
+            } finally {
+                assertTrue(SQLiteDatabase.deleteDatabase(targetContext.getDatabasePath(databaseHelper.databaseName)))
+            }
+        }
+    }
+
+    @Test
+    fun transactedReads() {
+        val statements = Array(1_000) {
+            Pair("SELECT * FROM 'Foo' WHERE bar=?", arrayOf<String?>("$it"))
+        }
+        benchmarkRule.measureRepeated {
+            inputs.block(databaseHelper.writableDatabase, statements)
+        }
+    }
+}

--- a/AndroidLibBenchmark/src/main/AndroidManifest.xml
+++ b/AndroidLibBenchmark/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.bloomberg.selekt.android.benchmark" />

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -20,6 +20,7 @@ enum class Versions(
     val version: String,
     private val url: URL
 ) {
+    ANDROID_BENCHMARK_GRADLE_PLUGIN("1.1.0-alpha06", URL("https://developer.android.com/studio/profile/benchmark")),
     ANDROID_BUILD_TOOLS("31.0.0", URL("https://developer.android.com/studio/releases/build-tools")),
     ANDROID_GRADLE_PLUGIN("7.0.0", URL("https://developer.android.com/tools/revisions/gradle-plugin.html")),
     ANDROID_LINT("30.0.0", URL("https://github.com/googlesamples/android-custom-lint-rules")),
@@ -35,6 +36,7 @@ enum class Versions(
     JACOCO("0.8.7", URL("https://www.jacoco.org/jacoco/trunk/doc/changes.html")),
     JMH("1.33", URL("https://openjdk.java.net/projects/code-tools/jmh/")),
     JSR_305("3.0.2", URL("https://code.google.com/archive/p/jsr-305/")),
+    JUNIT4("4.13.1", URL("https://github.com/junit-team/junit4")),
     JUNIT5("5.7.2", URL("https://junit.org/junit5/")),
     JUNIT5_PLATFORM("1.7.2", URL("https://junit.org/junit5/")),
     KOTLIN("1.5.21", URL("https://github.com/JetBrains/kotlin")),

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,7 @@ rootProject.name = "Selekt"
 
 include(":AndroidCLI")
 include(":AndroidLib")
+include(":AndroidLibBenchmark")
 include(":AndroidLint")
 include(":AndroidSQLCipher")
 include(":Annotations")


### PR DESCRIPTION
### Excerpt

```
insertInt[WAL]                  min=513594ns
insertIntWithOnConflict[WAL]    min=486615ns
insertIntWithStatement[WAL]     min=313229ns
batchInsertInt[WAL]             min=300261ns
```

### Test

```
./gradlew :AndroidLibBenchmark:connectedAndroidTest

adb -s <device_id> shell logcat | grep "I Bench"
08-22 12:04:37.649 26318 26335 I Benchmark: SQLiteDatabaseCacheBenchmark.simpleSelectPreparedStatementCache[waste]Summary: median=932119130ns, mean=939077724ns, min=702542570ns, stddev=55362884ns, count=1
08-22 12:04:47.858 26318 26335 I Benchmark: SQLiteDatabaseIndexBenchmark.simpleSelect[index]Summary: median=36389275ns, mean=36306182ns, min=35921566ns, stddev=222355ns, count=1
08-22 12:05:05.369 26318 26335 I Benchmark: SQLiteDatabaseIndexBenchmark.simpleSelect[none]Summary: median=178041919ns, mean=178763797ns, min=177335904ns, stddev=1677427ns, count=1
08-22 12:05:22.231 26318 26335 I Benchmark: SQLiteDatabaseTransactedReadBenchmark.transactedReads[inside]Summary: median=172304783ns, mean=172574425ns, min=171471007ns, stddev=1168743ns, count=1
08-22 12:05:39.727 26318 26335 I Benchmark: SQLiteDatabaseTransactedReadBenchmark.transactedReads[outside]Summary: median=178104601ns, mean=178770618ns, min=177301580ns, stddev=2247587ns, count=1
08-22 12:05:42.445 26318 26335 I Benchmark: SQLiteJournalModeDatabaseBenchmark.batchInsertInt[DELETE]Summary: median=967344ns, mean=1050836ns, min=910469ns, stddev=166315ns, count=1
08-22 12:05:42.846 26318 26335 I Benchmark: SQLiteJournalModeDatabaseBenchmark.singleQuery[DELETE]Summary: median=28615ns, mean=28844ns, min=27126ns, stddev=1668ns, count=12
08-22 12:05:45.622 26318 26335 I Benchmark: SQLiteJournalModeDatabaseBenchmark.insertFiveUnboundIntsSequentiallyWithOnConflict[DELETE]Summary: median=2879037ns, mean=2910373ns, min=2761875ns, stddev=151977ns, count=1
08-22 12:05:53.841 26318 26335 I Benchmark: SQLiteJournalModeDatabaseBenchmark.queryAndInsertIntWithOnConflict[DELETE]Summary: median=2423724ns, mean=2496087ns, min=1941199ns, stddev=324045ns, count=1
08-22 12:05:55.973 26318 26335 I Benchmark: SQLiteJournalModeDatabaseBenchmark.insertInt[DELETE]Summary: median=1161745ns, mean=1257648ns, min=1115052ns, stddev=178363ns, count=1
08-22 12:05:58.652 26318 26335 I Benchmark: SQLiteJournalModeDatabaseBenchmark.insertIntWithStatement[DELETE]Summary: median=1029922ns, mean=1097837ns, min=907188ns, stddev=184405ns, count=1
08-22 12:06:01.171 26318 26335 I Benchmark: SQLiteJournalModeDatabaseBenchmark.insertIntWithOnConflict[DELETE]Summary: median=1155782ns, mean=1793275ns, min=1091407ns, stddev=3465438ns, count=1
08-22 12:06:06.476 26318 26335 I Benchmark: SQLiteJournalModeDatabaseBenchmark.insertTwentyUnboundIntsSequentiallyWithOnConflict[DELETE]Summary: median=20401591ns, mean=20695099ns, min=19352450ns, stddev=1675272ns, count=1
08-22 12:06:14.800 26318 26335 I Benchmark: SQLiteJournalModeDatabaseBenchmark.multiQueryAndInsertIntWithOnConflict[DELETE]Summary: median=3650495ns, mean=3708056ns, min=3007083ns, stddev=524563ns, count=1
08-22 12:06:23.004 26318 26335 I Benchmark: SQLiteJournalModeDatabaseBenchmark.multiQuery[DELETE]Summary: median=895209ns, mean=943963ns, min=656459ns, stddev=206059ns, count=1
08-22 12:06:34.606 26318 26335 I Benchmark: SQLiteJournalModeDatabaseBenchmark.queryLargeEntryWhileInsertWithOnConflict[DELETE]Summary: median=60531621ns, mean=64049413ns, min=57109954ns, stddev=8335809ns, count=1
08-22 12:06:35.652 26318 26335 I Benchmark: SQLiteJournalModeDatabaseBenchmark.batchInsertInt[WAL]Summary: median=309818ns, mean=367055ns, min=300261ns, stddev=107606ns, count=1
08-22 12:06:36.011 26318 26335 I Benchmark: SQLiteJournalModeDatabaseBenchmark.singleQuery[WAL]Summary: median=12753ns, mean=12905ns, min=11950ns, stddev=638ns, count=22
08-22 12:06:44.289 26318 26335 I Benchmark: SQLiteJournalModeDatabaseBenchmark.insertFiveUnboundIntsSequentiallyWithOnConflict[WAL]Summary: median=1950704ns, mean=1970881ns, min=1885469ns, stddev=100904ns, count=1
08-22 12:06:52.897 26318 26335 I Benchmark: SQLiteJournalModeDatabaseBenchmark.queryAndInsertIntWithOnConflict[WAL]Summary: median=2805964ns, mean=3594632ns, min=1612032ns, stddev=3935221ns, count=1
08-22 12:06:56.775 26318 26335 I Benchmark: SQLiteJournalModeDatabaseBenchmark.insertInt[WAL]Summary: median=535807ns, mean=1204578ns, min=513594ns, stddev=4279095ns, count=1
08-22 12:07:04.931 26318 26335 I Benchmark: SQLiteJournalModeDatabaseBenchmark.insertIntWithStatement[WAL]Summary: median=318282ns, mean=398027ns, min=313229ns, stddev=164819ns, count=1
08-22 12:07:06.322 26318 26335 I Benchmark: SQLiteJournalModeDatabaseBenchmark.insertIntWithOnConflict[WAL]Summary: median=508906ns, mean=1183686ns, min=486615ns, stddev=4261412ns, count=1
08-22 12:07:10.531 26318 26335 I Benchmark: SQLiteJournalModeDatabaseBenchmark.insertTwentyUnboundIntsSequentiallyWithOnConflict[WAL]Summary: median=18097892ns, mean=18293137ns, min=17885627ns, stddev=885868ns, count=1
08-22 12:07:18.850 26318 26335 I Benchmark: SQLiteJournalModeDatabaseBenchmark.multiQueryAndInsertIntWithOnConflict[WAL]Summary: median=3865860ns, mean=3968514ns, min=2162709ns, stddev=1014707ns, count=1
08-22 12:07:27.066 26318 26335 I Benchmark: SQLiteJournalModeDatabaseBenchmark.multiQuery[WAL]Summary: median=768802ns, mean=845155ns, min=516928ns, stddev=259082ns, count=1
08-22 12:07:38.123 26318 26335 I Benchmark: SQLiteJournalModeDatabaseBenchmark.queryLargeEntryWhileInsertWithOnConflict[WAL]Summary: median=37137035ns, mean=53729031ns, min=33400264ns, stddev=30018520ns, count=1
```