### PR TITLE
Further reduce OpenSSL libcrypto.a binary size.

### DIFF
--- a/.github/workflows/periodic-integration.yml
+++ b/.github/workflows/periodic-integration.yml
@@ -1,4 +1,4 @@
-name: 'Periodic Integration tests'
+name: 'Periodic Integration Tests'
 
 on:
   schedule:
@@ -24,6 +24,3 @@ jobs:
       - name: 'Integration tests'
         run: |
           ./gradlew integrationTest
-      - name: 'Benchmarks'
-        run: |
-          ./gradlew jmh

--- a/OpenSSL/build_libraries.sh
+++ b/OpenSSL/build_libraries.sh
@@ -60,11 +60,12 @@ esac
 OPENSSL_CONFIGURE_OPTIONS="-fPIC -fstack-protector-all no-idea no-camellia \
     no-seed no-bf no-blake2 no-cast no-rc2 no-rc4 no-rc5 no-md2 no-rmd160 \
     no-md4 no-ecdh no-sock no-ssl no-ssl3 \
-    no-chacha no-des no-dh no-dsa no-ec no-ecdsa no-ec2m no-ocb no-tls no-dtls \
+    no-cast no-chacha no-des no-dh no-dsa no-ec no-ecdsa no-ec2m no-ocb no-tls no-dtls no-nextprotoneg \
     no-poly1305 no-rfc3779 no-whirlpool no-scrypt no-srp \
     no-mdc2 no-engine no-ts no-sse2 \
+    no-sm2 no-sm3 no-sm4 no-ocsp no-cmac \
     no-srtp no-shared no-comp no-ct no-cms no-capieng \
-    no-deprecated no-autoerrinit"
+    no-deprecated no-autoerrinit no-stdio no-ui-console"
 
 TOOLCHAIN_BIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${TOOLCHAIN_SYSTEM}/bin/"
 PATH=${TOOLCHAIN_BIN}:${PATH}


### PR DESCRIPTION
ref #223 

### Before

```
% ls -la OpenSSL/build/libs/x86_64
3652430 22 Aug 20:28 libcrypto.a

% ls -la AndroidCLI/build/outputs/apk/debug/                                   
5672840 22 Aug 20:56 AndroidCLI-debug.apk
```

### After

```
% ls -la OpenSSL/build/libs/x86_64
3435414 22 Aug 21:50 libcrypto.a

% ls -la AndroidCLI/build/outputs/apk/debug/
5611894 22 Aug 22:02 AndroidCLI-debug.apk
```