### PR TITLE
Initial Blob reading and writing benchmark.

### DIFF
--- a/AndroidLibBenchmark/src/androidTest/kotlin/com/bloomberg/selekt/android/benchmark/SQLiteDatabaseBlobBenchmark.kt
+++ b/AndroidLibBenchmark/src/androidTest/kotlin/com/bloomberg/selekt/android/benchmark/SQLiteDatabaseBlobBenchmark.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2021 Bloomberg Finance L.P.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bloomberg.selekt.android.benchmark
+
+import android.content.Context
+import androidx.benchmark.junit4.BenchmarkRule
+import androidx.benchmark.junit4.measureRepeated
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import com.bloomberg.selekt.Experimental
+import com.bloomberg.selekt.SQLiteJournalMode
+import com.bloomberg.selekt.ZeroBlob
+import com.bloomberg.selekt.android.ISQLiteOpenHelper
+import com.bloomberg.selekt.android.SQLiteDatabase
+import com.bloomberg.selekt.android.SQLiteOpenHelper
+import com.bloomberg.selekt.android.SQLiteOpenParams
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+private fun createSQLiteOpenHelper(
+    context: Context
+): ISQLiteOpenHelper = SQLiteOpenHelper(
+    context,
+    ISQLiteOpenHelper.Configuration(
+        callback = BlobSQLiteSupportOpenHelperCallback,
+        key = "a".repeat(32).toByteArray(StandardCharsets.UTF_8),
+        name = "test-index"
+    ),
+    1,
+    SQLiteOpenParams(SQLiteJournalMode.WAL)
+)
+
+private object BlobSQLiteSupportOpenHelperCallback : ISQLiteOpenHelper.Callback {
+    override fun onCreate(database: SQLiteDatabase) {
+        database.apply {
+            exec("CREATE TABLE 'Foo' (data BLOB)")
+            exec("INSERT INTO 'Foo' VALUES (?)", arrayOf(ZeroBlob(10 * 1_000_000)))
+        }
+    }
+
+    override fun onUpgrade(database: SQLiteDatabase, oldVersion: Int, newVersion: Int) = Unit
+}
+
+data class BlobInputs(
+    private val description: String,
+    val numberOfBytes: Int
+) {
+    override fun toString() = description
+}
+
+@LargeTest
+@RunWith(Parameterized::class)
+internal class SQLiteDatabaseBlobBenchmark(private val inputs: BlobInputs) {
+    @get:Rule
+    val benchmarkRule = BenchmarkRule()
+
+    private val targetContext: Context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private val databaseHelper = inputs.run { createSQLiteOpenHelper(targetContext) }
+
+    companion object {
+        @Parameters(name = "{0}")
+        @JvmStatic
+        fun initParameters(): Iterable<BlobInputs> = arrayOf(
+            BlobInputs("tiny", 100),
+            BlobInputs("small", 16 * 1_000),
+            BlobInputs("medium", 500 * 1_000),
+            BlobInputs("large", 10 * 1_000_000)
+        ).asIterable()
+    }
+
+    @After
+    fun tearDown() {
+        databaseHelper.writableDatabase.run {
+            try {
+                close()
+                assertFalse(isOpen)
+            } finally {
+                assertTrue(SQLiteDatabase.deleteDatabase(targetContext.getDatabasePath(databaseHelper.databaseName)))
+            }
+        }
+    }
+
+    @OptIn(Experimental::class)
+    @Test
+    fun readBlob() {
+        ByteArray(inputs.numberOfBytes) { 0x42 }.inputStream().use {
+            databaseHelper.writableDatabase.writeToBlob("Foo", "data", 1L, 0, it)
+        }
+        benchmarkRule.measureRepeated {
+            ByteArrayOutputStream(inputs.numberOfBytes).use {
+                databaseHelper.writableDatabase.readFromBlob("Foo", "data", 1L, 0, inputs.numberOfBytes, it)
+            }
+        }
+    }
+
+    @OptIn(Experimental::class)
+    @Test
+    fun writeBlob() {
+        val blob = ByteArray(inputs.numberOfBytes) { 0x42 }
+        benchmarkRule.measureRepeated {
+            blob.inputStream().use {
+                databaseHelper.writableDatabase.writeToBlob("Foo", "data", 1L, 0, it)
+            }
+        }
+    }
+}


### PR DESCRIPTION
```
% ./gradlew :AndroidLibBenchmark:connectedCheck
% adb -s <device_id> logcat | grep "I Bench"      

08-29 12:48:38.260  6585  6609 I Benchmark: SQLiteDatabaseBlobBenchmark.readBlob[tiny]Summary: median=58095ns, mean=58637ns, min=55332ns, stddev=2264ns, count=8
08-29 12:48:49.088  6585  6609 I Benchmark: SQLiteDatabaseBlobBenchmark.readBlob[small]Summary: median=158646ns, mean=162907ns, min=153680ns, stddev=18486ns, count=3
08-29 12:49:00.707  6585  6609 I Benchmark: SQLiteDatabaseBlobBenchmark.readBlob[medium]Summary: median=1262866ns, mean=1303500ns, min=1187135ns, stddev=187044ns, count=1
08-29 12:49:55.086  6585  6609 I Benchmark: SQLiteDatabaseBlobBenchmark.readBlob[large]Summary: median=152255953ns, mean=152407477ns, min=148809077ns, stddev=1774984ns, count=1

08-29 12:48:37.483  6585  6609 I Benchmark: SQLiteDatabaseBlobBenchmark.writeBlob[tiny]Summary: median=167122ns, mean=183657ns, min=161953ns, stddev=66782ns, count=2
08-29 12:48:46.385  6585  6609 I Benchmark: SQLiteDatabaseBlobBenchmark.writeBlob[small]Summary: median=505391ns, mean=514495ns, min=484687ns, stddev=27112ns, count=1
08-29 12:48:57.846  6585  6609 I Benchmark: SQLiteDatabaseBlobBenchmark.writeBlob[medium]Summary: median=9192032ns, mean=12631558ns, min=8907345ns, stddev=8842029ns, count=1
08-29 12:49:40.176  6585  6609 I Benchmark: SQLiteDatabaseBlobBenchmark.writeBlob[large]Summary: median=438063195ns, mean=439234946ns, min=399342175ns, stddev=11360143ns, count=1
```