### PR TITLE
Adding to ConcurrentLinkedQueue does not fail, remove failure branch as it cannot be tested.

### DIFF
--- a/Lib/src/main/kotlin/com/bloomberg/selekt/pools/Mutex.kt
+++ b/Lib/src/main/kotlin/com/bloomberg/selekt/pools/Mutex.kt
@@ -39,17 +39,13 @@ internal class Mutex {
         check(awaitLock(Long.MIN_VALUE, true)) { "Failed to acquire lock." }
     }
 
-    fun tryLock(
-        nanos: Long,
-        isCancellable: Boolean = true
-    ): Boolean {
-        require(nanos >= 0L) { "Nanos must be non-negative." }
+    fun tryLock(isCancellable: Boolean = true): Boolean {
         if (Thread.interrupted()) {
             throw InterruptedException()
         } else if (isCancellable && isCancelled()) {
             cancellationError()
         }
-        return awaitLock(nanos, isCancellable)
+        return awaitLock(0L, isCancellable)
     }
 
     fun unlock() {
@@ -85,10 +81,9 @@ internal class Mutex {
 
     @Generated
     inline fun <R> withTryLock(
-        nanos: Long,
         isCancellable: Boolean,
         block: () -> R
-    ): R? = if (tryLock(nanos, isCancellable)) {
+    ): R? = if (tryLock(isCancellable)) {
         try {
             block()
         } finally {

--- a/Lib/src/main/kotlin/com/bloomberg/selekt/pools/Mutex.kt
+++ b/Lib/src/main/kotlin/com/bloomberg/selekt/pools/Mutex.kt
@@ -112,10 +112,7 @@ internal class Mutex {
         intervalNanos: Long,
         isCancellable: Boolean
     ): Boolean {
-        val thread = Thread.currentThread()
-        if (!waiters.add(thread)) {
-            return false
-        }
+        waiters.add(Thread.currentThread())
         var remainingNanos = intervalNanos
         val deadlineNanos = System.nanoTime() + intervalNanos
         while (!(isThisHead() && internalTryLock())) {
@@ -148,7 +145,7 @@ internal class Mutex {
 
     private fun removeThisWaiterNotifyingNext() {
         isThisHead().also {
-            check(waiters.remove(Thread.currentThread())) { "Failed to remove waiter." }
+            waiters.remove(Thread.currentThread())
             if (it) {
                 LockSupport.unpark(waiters.peek())
             }

--- a/Lib/src/main/kotlin/com/bloomberg/selekt/pools/SingleObjectPool.kt
+++ b/Lib/src/main/kotlin/com/bloomberg/selekt/pools/SingleObjectPool.kt
@@ -54,7 +54,7 @@ class SingleObjectPool<K : Any, T : IPooledObject<K>>(
 
     override fun borrowObject(key: K) = borrowObject()
 
-    fun borrowObjectOrNull() = if (mutex.tryLock(0L, true)) {
+    fun borrowObjectOrNull() = if (mutex.tryLock()) {
         acquireObject()
     } else {
         null
@@ -84,7 +84,7 @@ class SingleObjectPool<K : Any, T : IPooledObject<K>>(
             priority.isHigh() -> withTryLock {
                 evictions(priority)
             }
-            else -> withTryLock(0L, false) {
+            else -> withTryLock(false) {
                 if (priority != null) {
                     obj?.releaseMemory()
                 }


### PR DESCRIPTION
Also remove passing timeout for `Mutex.tryLock` as in practice all intervals are zero nanos.