### PR TITLE
Increase Nexus publishing transition check retries to 180 (from default of 60), make default delay between explicit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@
 
 import io.gitlab.arturbosch.detekt.Detekt
 import java.net.URL
+import java.time.Duration
 import java.util.Locale
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -52,6 +53,10 @@ logger.quiet("Group: $group; Version: $version")
 nexusPublishing {
     repositories {
         sonatype()
+    }
+    transitionCheckOptions {
+        maxRetries.set(180)
+        delayBetween.set(Duration.ofSeconds(10L))
     }
 }
 


### PR DESCRIPTION
ref https://github.com/gradle-nexus/publish-plugin#retries-for-state-transitions