### PR TITLE
Integrate Kover 0.5.0-RC.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -75,7 +75,7 @@ jobs:
         ./gradlew assembleSelekt ${{ env.SCAN }}
     - name: 'Verify coverage'
       run:
-        ./gradlew :jacocoSelektCoverageVerification
+        ./gradlew :jacocoSelektCoverageVerification :koverVerify
     - name: 'Build others'
       run: |
         ./gradlew assembleAndroidTest :AndroidCLI:assembleDebug :AndroidLint:assemble jmhClasses

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -60,7 +60,7 @@ jobs:
       run: ./gradlew :AndroidLib:testDebugUnitTest :Lib:test ${{ env.SCAN }}
     - name: 'Coverage'
       run: |
-        ./gradlew :jacocoSelektTestReport ${{ env.SCAN }}
+        ./gradlew :jacocoSelektTestReport :koverHtmlReport ${{ env.SCAN }}
         bash scripts/codecov
     - uses: actions/upload-artifact@v2
       if: always()
@@ -68,6 +68,7 @@ jobs:
         name: 'Unit test reports'
         path: |
           build/reports/jacoco/jacocoSelektTestReport
+          build/reports/kover/html
           AndroidLib/build/reports/tests/testDebugUnitTest
           Lib/build/reports/tests/test
     - name: 'Build Selekt'

--- a/AndroidLib/build.gradle.kts
+++ b/AndroidLib/build.gradle.kts
@@ -27,7 +27,6 @@ plugins {
     kotlin("kapt")
     signing
     `maven-publish`
-    id("org.jetbrains.kotlinx.kover") apply false
 }
 
 repositories {

--- a/AndroidLib/build.gradle.kts
+++ b/AndroidLib/build.gradle.kts
@@ -15,6 +15,7 @@
  */
 
 import java.util.Locale
+import kotlinx.kover.api.KoverTaskExtension
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
 
 plugins {
@@ -26,6 +27,7 @@ plugins {
     kotlin("kapt")
     signing
     `maven-publish`
+    id("org.jetbrains.kotlinx.kover") apply false
 }
 
 repositories {
@@ -58,6 +60,16 @@ android {
         sourceSets[it].java.srcDir("src/$it/kotlin")
     }
     sourceSets["test"].resources.srcDir("$buildDir/intermediates/libs")
+
+    testOptions {
+        unitTests.all {
+            if (!it.name.contains("debug", ignoreCase = true)) {
+                it.extensions.configure<KoverTaskExtension> {
+                    isDisabled = true
+                }
+            }
+        }
+    }
 }
 
 dependencies {

--- a/Lib/build.gradle.kts
+++ b/Lib/build.gradle.kts
@@ -16,6 +16,8 @@
 
 @file:Suppress("UnstableApiUsage")
 
+import kotlinx.kover.api.KoverTaskExtension
+
 repositories {
     mavenCentral()
 }
@@ -28,6 +30,7 @@ plugins {
     `maven-publish`
     signing
     id("bb-jmh")
+    id("org.jetbrains.kotlinx.kover") apply false
 }
 
 disableKotlinCompilerAssertions()
@@ -93,6 +96,9 @@ tasks.register<Test>("integrationTest") {
     outputs.cacheIf { false }
     dependsOn("buildHostSQLite")
     shouldRunAfter("test")
+    extensions.configure<KoverTaskExtension> {
+        isDisabled = true
+    }
 }
 
 tasks.register<Task>("buildHostSQLite") {

--- a/Lib/build.gradle.kts
+++ b/Lib/build.gradle.kts
@@ -30,7 +30,6 @@ plugins {
     `maven-publish`
     signing
     id("bb-jmh")
-    id("org.jetbrains.kotlinx.kover") apply false
 }
 
 disableKotlinCompilerAssertions()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ import io.gitlab.arturbosch.detekt.Detekt
 import java.net.URL
 import java.time.Duration
 import java.util.Locale
+import kotlinx.kover.api.VerificationValueType
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
@@ -32,6 +33,7 @@ plugins {
     id("io.gitlab.arturbosch.detekt") version Versions.DETEKT.version
     id("io.github.gradle-nexus.publish-plugin") version Versions.NEXUS_PLUGIN.version
     id("org.jetbrains.dokka") version Versions.DOKKA.version
+    id("org.jetbrains.kotlinx.kover") version Versions.KOTLINX_KOVER.version
     id("org.jlleitschuh.gradle.ktlint") version Versions.KTLINT_GRADLE_PLUGIN.version
 }
 
@@ -238,4 +240,18 @@ tasks.register<JacocoCoverageVerification>("jacocoSelektCoverageVerification") {
         }
     }
     mustRunAfter("jacocoSelektTestReport")
+}
+
+kover {
+    disabledProjects = setOf(":AndroidCli", ":AndroidLibBenchmark")
+}
+
+tasks.koverVerify {
+    rule {
+        name = "Minimal line coverage"
+        bound {
+            minValue = 97
+            valueType = VerificationValueType.COVERED_LINES_PERCENTAGE
+        }
+    }
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -42,6 +42,7 @@ enum class Versions(
     KOTLIN("1.6.10", URL("https://github.com/JetBrains/kotlin")),
     KOTLIN_COROUTINES("1.5.2", URL("https://github.com/Kotlin/kotlinx.coroutines")),
     KOTLIN_TEST("1.4.32", URL("https://github.com/JetBrains/kotlin")),
+    KOTLINX_KOVER("0.5.0-RC", URL("https://github.com/Kotlin/kotlinx-kover")),
     KTLINT("0.43.2", URL("https://github.com/pinterest/ktlint")),
     KTLINT_GRADLE_PLUGIN("10.2.1", URL("https://github.com/JLLeitschuh/ktlint-gradle")),
     MOCKITO("4.0.0", URL("https://github.com/mockito/mockito")),


### PR DESCRIPTION
```
./gradlew koverHtmlReport
./gradlew koverVerify
```

For sample report see for instance https://github.com/bloomberg/selekt/actions/runs/1671098053 and click "Unit test reports" artifact.

<img width="1324" alt="Screenshot 2022-01-08 at 10 05 11" src="https://user-images.githubusercontent.com/291757/148640193-7b258b9b-93cd-4b46-88b5-69acb7cfffc7.png">

Note a redundant release build of AndroidLib et al triggered, and includes `BuildConfig` class in coverage. Both need massaging out.

Inline methods clocked in coverage:

<img width="636" alt="Screenshot 2022-01-08 at 10 08 42" src="https://user-images.githubusercontent.com/291757/148640276-379c9c3a-bec5-41e8-b85f-841d2fa47801.png">

