### PR TITLE
Use JvmSynthetic to conceal from Java methods annotated PublishedApi internal for the benefit of inlined callers.

### DIFF
--- a/Lib/src/main/kotlin/com/bloomberg/selekt/commons/ManagedStringBuilder.kt
+++ b/Lib/src/main/kotlin/com/bloomberg/selekt/commons/ManagedStringBuilder.kt
@@ -29,6 +29,7 @@ class ManagedStringBuilder(
         require(maxRetainedLength > 0)
     }
 
+    @get:JvmSynthetic @set:JvmSynthetic
     @PublishedApi
     @JvmField
     internal var builder = StringBuilder(defaultLength)
@@ -44,13 +45,13 @@ class ManagedStringBuilder(
         }
     }
 
-    @PublishedApi internal fun validate() = builder.length <= maxRetainedLength
+    @JvmSynthetic @PublishedApi internal fun validate() = builder.length <= maxRetainedLength
 
-    @PublishedApi internal fun passivate() {
+    @JvmSynthetic @PublishedApi internal fun passivate() {
         builder.clear()
     }
 
-    @PublishedApi internal fun reset() {
+    @JvmSynthetic @PublishedApi internal fun reset() {
         builder = StringBuilder(defaultLength)
     }
 }


### PR DESCRIPTION
ref https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/-jvm-synthetic/