### PR TITLE
Address log warnings with manual configuration of source and target compatibility for Android.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,6 +97,10 @@ subprojects {
     listOf("com.android.application", "com.android.library").forEach {
         plugins.withId(it) {
             extensions.getByType<TestedExtension>().apply {
+                compileOptions {
+                    sourceCompatibility = JavaVersion.VERSION_11
+                    targetCompatibility = JavaVersion.VERSION_11
+                }
                 lintOptions {
                     isWarningsAsErrors = true
                 }


### PR DESCRIPTION
https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support

```
> Task :AndroidCLI:compileDebugKotlin
'compileDebugJavaWithJavac' task (current target is 1.8) and 'compileDebugKotlin' task (current target is 11) jvm target compatibility should be set to the same Java version.
By default will become an error since Gradle 8.0+! Read more: https://kotl.in/gradle/jvm/target-validation
Consider using JVM toolchain: https://kotl.in/gradle/jvm/toolchain
```