### PR TITLE
Model SQLStatementInformation as non-data class to avoid needing to override equals et al.

### DIFF
--- a/selekt-java/src/main/kotlin/com/bloomberg/selekt/SQLStatement.kt
+++ b/selekt-java/src/main/kotlin/com/bloomberg/selekt/SQLStatement.kt
@@ -233,8 +233,8 @@ internal class SQLStatement private constructor(
     }
 }
 
-@Suppress("ArrayInDataClass")
-internal data class SQLStatementInformation(
+@Suppress("UseDataClass")
+internal class SQLStatementInformation(
     val isReadOnly: Boolean,
     val parameterCount: Int,
     val columnNames: Array<out String>


### PR DESCRIPTION
Flagged by SonarQube.