### PR TITLE
Replace scheduleAtFixedRate when evicting with scheduleWithFixedDelay from the connection pools.

### DIFF
--- a/selekt-java/src/main/kotlin/com/bloomberg/selekt/pools/CommonObjectPool.kt
+++ b/selekt-java/src/main/kotlin/com/bloomberg/selekt/pools/CommonObjectPool.kt
@@ -181,7 +181,7 @@ class CommonObjectPool<K : Any, T : IPooledObject<K>>(
         if (future?.isCancelled == false || configuration.evictionIntervalMillis < 0L || isClosed.get()) {
             return
         }
-        future = executor.scheduleAtFixedRate(
+        future = executor.scheduleWithFixedDelay(
             ::evict,
             configuration.evictionDelayMillis,
             configuration.evictionIntervalMillis,

--- a/selekt-java/src/main/kotlin/com/bloomberg/selekt/pools/SingleObjectPool.kt
+++ b/selekt-java/src/main/kotlin/com/bloomberg/selekt/pools/SingleObjectPool.kt
@@ -97,7 +97,6 @@ class SingleObjectPool<K : Any, T : IPooledObject<K>>(
         }
     }?.let {
         factory.destroyObject(it)
-        attemptScheduleEviction()
     }
 
     @GuardedBy("mutex")

--- a/selekt-java/src/main/kotlin/com/bloomberg/selekt/pools/SingleObjectPool.kt
+++ b/selekt-java/src/main/kotlin/com/bloomberg/selekt/pools/SingleObjectPool.kt
@@ -97,6 +97,7 @@ class SingleObjectPool<K : Any, T : IPooledObject<K>>(
         }
     }?.let {
         factory.destroyObject(it)
+        attemptScheduleEviction()
     }
 
     @GuardedBy("mutex")
@@ -118,7 +119,7 @@ class SingleObjectPool<K : Any, T : IPooledObject<K>>(
         if (evictionIntervalMillis < 0L || isClosed) {
             return
         }
-        future = executor.scheduleAtFixedRate(
+        future = executor.scheduleWithFixedDelay(
             ::evict,
             evictionDelayMillis,
             evictionIntervalMillis,

--- a/selekt-java/src/test/kotlin/com/bloomberg/selekt/pools/CommonObjectPoolTest.kt
+++ b/selekt-java/src/test/kotlin/com/bloomberg/selekt/pools/CommonObjectPoolTest.kt
@@ -360,17 +360,16 @@ internal class CommonObjectPoolTest {
 
     @Test
     fun interleavedBorrowSchedulesEvictionIfCancelled() {
-        @Suppress("JoinDeclarationAndAssignment")
         lateinit var pool: CommonObjectPool<String, PooledObject>
         val executor = object : ScheduledExecutorService by this@CommonObjectPoolTest.executor {
             var count = 0
 
-            override fun scheduleAtFixedRate(
+            override fun scheduleWithFixedDelay(
                 command: Runnable,
                 initialDelay: Long,
-                period: Long,
+                delay: Long,
                 unit: TimeUnit
-            ) = this@CommonObjectPoolTest.executor.scheduleAtFixedRate(command, initialDelay, period, unit).also {
+            ) = this@CommonObjectPoolTest.executor.scheduleWithFixedDelay(command, initialDelay, delay, unit).also {
                 if (count++ == 0) {
                     it.cancel(false)
                 }
@@ -459,12 +458,12 @@ internal class CommonObjectPoolTest {
     @Test
     fun evictionFailsIfCancelled() {
         val executor = object : ScheduledExecutorService by this@CommonObjectPoolTest.executor {
-            override fun scheduleAtFixedRate(
+            override fun scheduleWithFixedDelay(
                 command: Runnable,
                 initialDelay: Long,
-                period: Long,
+                delay: Long,
                 unit: TimeUnit
-            ) = this@CommonObjectPoolTest.executor.scheduleAtFixedRate(command, initialDelay, period, unit).apply {
+            ) = this@CommonObjectPoolTest.executor.scheduleWithFixedDelay(command, initialDelay, delay, unit).apply {
                 cancel(false)
             }
         }

--- a/selekt-java/src/test/kotlin/com/bloomberg/selekt/pools/SingleObjectPoolTest.kt
+++ b/selekt-java/src/test/kotlin/com/bloomberg/selekt/pools/SingleObjectPoolTest.kt
@@ -349,12 +349,12 @@ internal class SingleObjectPoolTest {
     @Test
     fun evictionFailsIfCancelled() {
         val executor = object : ScheduledExecutorService by this@SingleObjectPoolTest.executor {
-            override fun scheduleAtFixedRate(
+            override fun scheduleWithFixedDelay(
                 command: Runnable,
                 initialDelay: Long,
-                period: Long,
+                delay: Long,
                 unit: TimeUnit
-            ) = this@SingleObjectPoolTest.executor.scheduleAtFixedRate(command, initialDelay, period, unit).apply {
+            ) = this@SingleObjectPoolTest.executor.scheduleAtFixedRate(command, initialDelay, delay, unit).apply {
                 cancel(false)
             }
         }
@@ -382,10 +382,8 @@ internal class SingleObjectPoolTest {
 
     @Test
     fun borrowAsClosingDoesNotScheduleEviction() {
-        @Suppress("JoinDeclarationAndAssignment")
-        lateinit var pool: SingleObjectPool<String, PooledObject>
         val executor = mock<ScheduledExecutorService>()
-        pool = SingleObjectPool(object : IObjectFactory<PooledObject> {
+        val pool = SingleObjectPool(object : IObjectFactory<PooledObject> {
             override fun close() = Unit
 
             override fun destroyObject(obj: PooledObject) = Unit


### PR DESCRIPTION
<img width="1436" alt="Screenshot 2024-06-25 at 08 10 54" src="https://github.com/bloomberg/selekt/assets/291757/00ab5da5-e98c-474b-b76d-d2921e4b4c4c">