### PR TITLE
Support compiling 16 KB-aligned shared libraries with Android NDK version r27 and higher.

### DIFF
--- a/selekt-android-sqlcipher/build.gradle.kts
+++ b/selekt-android-sqlcipher/build.gradle.kts
@@ -43,6 +43,12 @@ android {
     ndkVersion = "27.0.12077973"
     defaultConfig {
         minSdk = 21
+        @Suppress("UnstableApiUsage")
+        externalNativeBuild {
+            cmake {
+                arguments("-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON")
+            }
+        }
     }
     buildTypes {
         debug {


### PR DESCRIPTION
xref https://developer.android.com/guide/practices/page-sizes#compile-r27-higher