### PR TITLE
Address deprecation of GitHub actions/upload-artifact@v3, update to v4.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -53,7 +53,7 @@ jobs:
       run: ./gradlew licensee --no-configuration-cache
     - name: 'Analyse'
       run: ./gradlew detekt ktlintCheck lint -x lintRelease ${{ env.SCAN }}
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: 'Analyses'
@@ -61,7 +61,7 @@ jobs:
           **/build/reports/detekt
     - name: 'Unit tests'
       run: ./gradlew :selekt-android:testDebugUnitTest :selekt-java:test :koverHtmlReport -x integrationTest ${{ env.SCAN }}
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: 'Unit test and coverage reports'


### PR DESCRIPTION
xref https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

> Starting November 30, 2024, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact). Customers should update workflows to begin using [v4 of the artifact actions](https://github.blog/2024-02-12-get-started-with-v4-of-github-actions-artifacts/) as soon as possible.