### PR TITLE
Fix concurrent reads during writes and WAL checkpoint blocking

### DIFF
--- a/selekt-jdbc/src/main/kotlin/com/bloomberg/selekt/jdbc/connection/JdbcConnection.kt
+++ b/selekt-jdbc/src/main/kotlin/com/bloomberg/selekt/jdbc/connection/JdbcConnection.kt
@@ -17,7 +17,6 @@
 package com.bloomberg.selekt.jdbc.connection
 
 import com.bloomberg.selekt.SQLDatabase
-import com.bloomberg.selekt.SQLitePragma
 import com.bloomberg.selekt.commons.forEachCatching
 import com.bloomberg.selekt.jdbc.driver.SharedDatabase
 import com.bloomberg.selekt.jdbc.exception.SQLExceptionMapper
@@ -338,7 +337,6 @@ internal class JdbcConnection(
 
     override fun setReadOnly(readOnly: Boolean) {
         checkClosed()
-        database.pragma(SQLitePragma.QUERY_ONLY, if (readOnly) { 1 } else { 0 })
         this.readOnly = readOnly
     }
 
@@ -493,8 +491,14 @@ internal class JdbcConnection(
     }
 
     internal fun ensureTransaction() {
-        if (!autoCommit && !database.inTransaction) {
+        if (!autoCommit && !readOnly && !database.inTransaction) {
             database.beginImmediateTransaction()
+        }
+    }
+
+    internal fun checkWritable() {
+        if (readOnly) {
+            throw SQLException("attempt to write a readonly database (SQLITE_READONLY)")
         }
     }
 

--- a/selekt-jdbc/src/main/kotlin/com/bloomberg/selekt/jdbc/statement/JdbcPreparedStatement.kt
+++ b/selekt-jdbc/src/main/kotlin/com/bloomberg/selekt/jdbc/statement/JdbcPreparedStatement.kt
@@ -103,8 +103,7 @@ internal open class JdbcPreparedStatement(
         checkClosed()
         return runCatching {
             closeCurrentResultSet()
-            connection.ensureTransaction()
-            val cursor = if (getResultSetType() == ResultSet.TYPE_FORWARD_ONLY) {
+            val cursor = if (getResultSetType() == ResultSet.TYPE_FORWARD_ONLY && !connection.isReadOnly) {
                 database.queryForwardOnly(applyMaxRows(sql), parameters)
             } else {
                 database.query(applyMaxRows(sql), parameters)
@@ -123,6 +122,7 @@ internal open class JdbcPreparedStatement(
 
     override fun executeUpdate(): Int {
         checkClosed()
+        connection.checkWritable()
         return try {
             connection.ensureTransaction()
             executeUpdate(database.compileStatement(sql, parameters))
@@ -137,12 +137,12 @@ internal open class JdbcPreparedStatement(
         checkClosed()
         return try {
             closeCurrentResultSet()
-            connection.ensureTransaction()
             val statement = database.compileStatement(sql, parameters)
             if (statement.isReadOnly) {
                 executeQuery()
                 true
             } else {
+                connection.checkWritable()
                 executeUpdate(statement)
                 false
             }

--- a/selekt-jdbc/src/main/kotlin/com/bloomberg/selekt/jdbc/statement/JdbcStatement.kt
+++ b/selekt-jdbc/src/main/kotlin/com/bloomberg/selekt/jdbc/statement/JdbcStatement.kt
@@ -75,8 +75,7 @@ open class JdbcStatement internal constructor(
         checkClosed()
         try {
             closeCurrentResultSet()
-            connection.ensureTransaction()
-            val cursor = if (resultSetType == ResultSet.TYPE_FORWARD_ONLY) {
+            val cursor = if (resultSetType == ResultSet.TYPE_FORWARD_ONLY && !connection.isReadOnly) {
                 database.queryForwardOnly(applyMaxRows(sql), emptyArray())
             } else {
                 database.query(applyMaxRows(sql), emptyArray())
@@ -91,6 +90,7 @@ open class JdbcStatement internal constructor(
 
     override fun executeUpdate(sql: String): Int {
         checkClosed()
+        connection.checkWritable()
         return try {
             closeCurrentResultSet()
             database.compileStatement(sql).use { executeUpdate(sql, it) }
@@ -105,7 +105,6 @@ open class JdbcStatement internal constructor(
         checkClosed()
         closeCurrentResultSet()
         val statement = runCatching {
-            connection.ensureTransaction()
             database.compileStatement(sql)
         }.getOrElse { e ->
             throw SQLExceptionMapper.mapException(e as? SQLException ?: SQLException(e.message, e))
@@ -115,6 +114,7 @@ open class JdbcStatement internal constructor(
                 executeQuery(sql)
                 true
             } else {
+                connection.checkWritable()
                 executeUpdate(sql, it)
                 false
             }

--- a/selekt-jdbc/src/test/kotlin/com/bloomberg/selekt/jdbc/connection/JdbcConnectionTest.kt
+++ b/selekt-jdbc/src/test/kotlin/com/bloomberg/selekt/jdbc/connection/JdbcConnectionTest.kt
@@ -22,12 +22,18 @@ import com.bloomberg.selekt.jdbc.driver.SharedDatabase
 import com.bloomberg.selekt.jdbc.statement.JdbcPreparedStatement
 import com.bloomberg.selekt.jdbc.statement.JdbcStatement
 import com.bloomberg.selekt.jdbc.util.ConnectionURL
+import java.io.File
 import java.sql.Connection
+import java.sql.DriverManager
 import java.sql.ResultSet
 import java.sql.SQLException
 import java.sql.Savepoint
 import java.util.Properties
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
 import kotlin.test.assertNotSame
 import kotlin.test.assertSame
 import kotlin.test.assertEquals
@@ -215,16 +221,18 @@ internal class JdbcConnectionTest {
     }
 
     @Test
-    fun setReadOnlyEnforcesQueryOnlyPragma(): Unit = connection.run {
+    fun setReadOnlyDoesNotApplyPragmaToSharedDatabase(): Unit = connection.run {
         isReadOnly = true
-        verify(mockDatabase).pragma(SQLitePragma.QUERY_ONLY, 1)
+        verify(mockDatabase, never()).pragma(SQLitePragma.QUERY_ONLY, 1)
+        assertTrue(isReadOnly)
     }
 
     @Test
-    fun clearReadOnlyClearsQueryOnlyPragma(): Unit = connection.run {
+    fun clearReadOnlyDoesNotApplyPragmaToSharedDatabase(): Unit = connection.run {
         isReadOnly = true
         isReadOnly = false
-        verify(mockDatabase).pragma(SQLitePragma.QUERY_ONLY, 0)
+        verify(mockDatabase, never()).pragma(SQLitePragma.QUERY_ONLY, 0)
+        assertFalse(isReadOnly)
     }
 
     @Test
@@ -934,6 +942,48 @@ internal class JdbcConnectionTest {
     }
 
     @Test
+    fun ensureTransactionReadOnlyNotCalledWhenInTransaction() {
+        val database = mock<SQLDatabase> {
+            whenever(it.inTransaction) doReturn true
+        }
+        JdbcConnection(SharedDatabase(database), connectionURL, properties).apply {
+            isReadOnly = true
+            autoCommit = false
+            ensureTransaction()
+        }
+        verify(database, never()).beginDeferredTransaction()
+        verify(database, never()).beginImmediateTransaction()
+    }
+
+    @Test
+    fun ensureTransactionReadOnlyNotCalledInAutoCommit() {
+        val database = mock<SQLDatabase> {
+            whenever(it.inTransaction) doReturn false
+        }
+        JdbcConnection(SharedDatabase(database), connectionURL, properties).apply {
+            isReadOnly = true
+            autoCommit = true
+            ensureTransaction()
+        }
+        verify(database, never()).beginDeferredTransaction()
+        verify(database, never()).beginImmediateTransaction()
+    }
+
+    @Test
+    fun ensureTransactionWritableUsesImmediateTransaction() {
+        val database = mock<SQLDatabase> {
+            whenever(it.inTransaction) doReturn false
+        }
+        JdbcConnection(SharedDatabase(database), connectionURL, properties).apply {
+            isReadOnly = false
+            autoCommit = false
+            ensureTransaction()
+        }
+        verify(database).beginImmediateTransaction()
+        verify(database, never()).beginDeferredTransaction()
+    }
+
+    @Test
     fun commitEndTransactionErrorHandling() {
         val database = mock<SQLDatabase> {
             whenever(it.inTransaction) doReturn true
@@ -1273,5 +1323,262 @@ internal class JdbcConnectionTest {
         extraStatement.close()
         val evictedStatement = connection.prepareStatement("SELECT 0") as JdbcPreparedStatement
         assertNotSame(statements[0], evictedStatement)
+    }
+
+    @Test
+    fun executeQueryOnReadOnlyConnectionDoesNotBeginTransaction() {
+        val database = mock<SQLDatabase> {
+            whenever(it.inTransaction) doReturn false
+        }
+        JdbcConnection(SharedDatabase(database), connectionURL, properties).use {
+            it.isReadOnly = true
+            it.autoCommit = false
+            it.ensureTransaction()
+            verify(database, never()).beginDeferredTransaction()
+            verify(database, never()).beginImmediateTransaction()
+            verify(database, never()).beginExclusiveTransaction()
+        }
+    }
+
+    @Test
+    fun readOnlyConnectionDoesNotBlockWalCheckpoint() {
+        val tempFile = File.createTempFile("selekt-wal-checkpoint-test-", ".db").apply(File::deleteOnExit)
+        val url = "jdbc:sqlite:${tempFile.absolutePath}?journalMode=WAL&busyTimeout=2000&poolSize=2"
+        try {
+            DriverManager.getConnection(url).use { writer ->
+                writer.createStatement().use { statement ->
+                    statement.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)")
+                    statement.execute("INSERT INTO test (value) VALUES ('row1')")
+                    statement.execute("INSERT INTO test (value) VALUES ('row2')")
+                }
+            }
+
+            val readerConnection = DriverManager.getConnection(url).apply {
+                isReadOnly = true
+                autoCommit = false
+            }
+            val readerStatement = readerConnection.createStatement()
+            val resultSet = readerStatement.executeQuery("SELECT * FROM test")
+            assertTrue(resultSet.next(), "Should have at least one row")
+
+            DriverManager.getConnection(url).use { writer ->
+                writer.createStatement().use { statement ->
+                    statement.execute("INSERT INTO test (value) VALUES ('row3')")
+                }
+            }
+
+            val checkpointSucceeded = runCatching {
+                DriverManager.getConnection(url).use { checkpointer ->
+                    checkpointer.createStatement().use { statement ->
+                        statement.execute("PRAGMA wal_checkpoint(FULL)")
+                    }
+                    true
+                }
+            }.getOrElse {
+                false
+            }
+
+            assertTrue(checkpointSucceeded, "WAL FULL checkpoint should succeed because " +
+                "read-only connections no longer hold a deferred transaction open.")
+
+            resultSet.close()
+            readerStatement.close()
+            readerConnection.close()
+        } finally {
+            tempFile.delete()
+            File("${tempFile.absolutePath}-wal").delete()
+            File("${tempFile.absolutePath}-shm").delete()
+        }
+    }
+
+    @Test
+    fun readOnlyPreparedStatementDoesNotBlockWalCheckpoint() {
+        val tempFile = File.createTempFile("selekt-wal-ps-checkpoint-test-", ".db").apply(File::deleteOnExit)
+        val url = "jdbc:sqlite:${tempFile.absolutePath}?journalMode=WAL&busyTimeout=2000&poolSize=2"
+        try {
+            DriverManager.getConnection(url).use { setup ->
+                setup.createStatement().use { statement ->
+                    statement.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)")
+                    statement.execute("INSERT INTO test (value) VALUES ('row1')")
+                    statement.execute("INSERT INTO test (value) VALUES ('row2')")
+                }
+            }
+
+            val readerConnection = DriverManager.getConnection(url).apply {
+                isReadOnly = true
+                autoCommit = false
+            }
+            val preparedStatement = readerConnection.prepareStatement("SELECT * FROM test WHERE id >= ?").apply {
+                setInt(1, 1)
+            }
+            val resultSet = preparedStatement.executeQuery()
+            assertTrue(resultSet.next(), "Should have at least one row")
+
+            DriverManager.getConnection(url).use { writer ->
+                writer.createStatement().use { statement ->
+                    statement.execute("INSERT INTO test (value) VALUES ('row3')")
+                }
+            }
+
+            val checkpointSucceeded = runCatching {
+                DriverManager.getConnection(url).use { checkpointer ->
+                    checkpointer.createStatement().use { statement ->
+                        statement.execute("PRAGMA wal_checkpoint(FULL)")
+                    }
+                    true
+                }
+            }.getOrElse {
+                false
+            }
+
+            assertTrue(checkpointSucceeded, "WAL FULL checkpoint should succeed because " +
+                "read-only PreparedStatement connections no longer hold a deferred transaction open.")
+
+            resultSet.close()
+            preparedStatement.close()
+            readerConnection.close()
+        } finally {
+            tempFile.delete()
+            File("${tempFile.absolutePath}-wal").delete()
+            File("${tempFile.absolutePath}-shm").delete()
+        }
+    }
+
+    @Suppress("Detekt.NestedBlockDepth")
+    @Test
+    fun readQueryOnSeparateThreadWhileWriteTransactionIsOpen() {
+        val tempFile = File.createTempFile("selekt-pool-concurrency-test-", ".db").apply(File::deleteOnExit)
+        val url = "jdbc:sqlite:${tempFile.absolutePath}?journalMode=WAL&busyTimeout=2000&poolSize=2"
+        try {
+            DriverManager.getConnection(url).use { setup ->
+                setup.createStatement().use { statement ->
+                    statement.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)")
+                    statement.execute("INSERT INTO test (value) VALUES ('seed')")
+                }
+            }
+
+            val writerConnection = DriverManager.getConnection(url)
+            val readerConnection = DriverManager.getConnection(url).apply {
+                isReadOnly = true
+            }
+
+            writerConnection.autoCommit = false
+
+            val readCompleted = CountDownLatch(1)
+            val readError = AtomicReference<Throwable>(null)
+            val readValue = AtomicReference<String>(null)
+
+            writerConnection.createStatement().use { statement ->
+                statement.execute("INSERT INTO test (value) VALUES ('in_transaction')")
+            }
+
+            thread(start = true, isDaemon = true) {
+                runCatching {
+                    readerConnection.createStatement().use { statement ->
+                        statement.executeQuery("SELECT value FROM test WHERE value = 'seed'").use { resultSet ->
+                            if (resultSet.next()) {
+                                readValue.set(resultSet.getString(1))
+                            }
+                        }
+                    }
+                }.onFailure {
+                    readError.set(it)
+                }
+                readCompleted.countDown()
+            }
+
+            assertTrue(readCompleted.await(5, TimeUnit.SECONDS),
+                "Read query on background thread should complete within timeout")
+            assertNull(readError.get(), "Read query should not throw: ${readError.get()?.message}")
+            assertEquals("seed", readValue.get(), "Background thread should have read the seed row")
+
+            writerConnection.commit()
+            writerConnection.close()
+            readerConnection.close()
+
+            DriverManager.getConnection(url).use { reader ->
+                reader.createStatement().use { statement ->
+                    statement.executeQuery("SELECT COUNT(*) FROM test").use { resultSet ->
+                        assertTrue(resultSet.next())
+                        assertEquals(2, resultSet.getInt(1))
+                    }
+                }
+            }
+        } finally {
+            tempFile.delete()
+            File("${tempFile.absolutePath}-wal").delete()
+            File("${tempFile.absolutePath}-shm").delete()
+        }
+    }
+
+    @Suppress("Detekt.LongMethod", "Detekt.NestedBlockDepth")
+    @Test
+    fun readOnlyTransactionOnSeparateThreadWhileWriteTransactionIsOpen() {
+        val tempFile = File.createTempFile("selekt-ro-txn-concurrency-test-", ".db").apply(File::deleteOnExit)
+        val url = "jdbc:sqlite:${tempFile.absolutePath}?journalMode=WAL&busyTimeout=2000&poolSize=2"
+        try {
+            DriverManager.getConnection(url).use { setup ->
+                setup.createStatement().use { statement ->
+                    statement.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)")
+                    statement.execute("INSERT INTO test (value) VALUES ('seed')")
+                }
+            }
+
+            val writerConnection = DriverManager.getConnection(url)
+            val readerConnection = DriverManager.getConnection(url).apply {
+                isReadOnly = true
+            }
+
+            writerConnection.autoCommit = false
+
+            val readCompleted = CountDownLatch(1)
+            val readError = AtomicReference<Throwable>(null)
+            val readValue = AtomicReference<String>(null)
+
+            writerConnection.createStatement().use { statement ->
+                statement.execute("INSERT INTO test (value) VALUES ('in_transaction')")
+            }
+
+            thread(start = true, isDaemon = true) {
+                runCatching {
+                    readerConnection.autoCommit = false
+                    readerConnection.createStatement().use { statement ->
+                        statement.executeQuery("SELECT value FROM test WHERE value = 'seed'").use { resultSet ->
+                            if (resultSet.next()) {
+                                readValue.set(resultSet.getString(1))
+                            }
+                        }
+                    }
+                    readerConnection.commit()
+                }.onFailure {
+                    readError.set(it)
+                }
+                readCompleted.countDown()
+            }
+
+            assertTrue(readCompleted.await(5, TimeUnit.SECONDS),
+                "Read-only transaction on background thread should complete within timeout")
+            assertNull(readError.get(),
+                "Read-only transaction should not throw: ${readError.get()?.message}")
+            assertEquals("seed", readValue.get(),
+                "Background thread should have read the seed row")
+
+            writerConnection.commit()
+            writerConnection.close()
+            readerConnection.close()
+
+            DriverManager.getConnection(url).use { reader ->
+                reader.createStatement().use { statement ->
+                    statement.executeQuery("SELECT COUNT(*) FROM test").use { resultSet ->
+                        assertTrue(resultSet.next())
+                        assertEquals(2, resultSet.getInt(1))
+                    }
+                }
+            }
+        } finally {
+            tempFile.delete()
+            File("${tempFile.absolutePath}-wal").delete()
+            File("${tempFile.absolutePath}-shm").delete()
+        }
     }
 }

--- a/selekt-jdbc/src/test/kotlin/com/bloomberg/selekt/jdbc/exposed/ExposedSelektTest.kt
+++ b/selekt-jdbc/src/test/kotlin/com/bloomberg/selekt/jdbc/exposed/ExposedSelektTest.kt
@@ -30,6 +30,7 @@ import org.jetbrains.exposed.sql.update
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.sql.Connection
 import java.sql.DriverManager
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
@@ -317,8 +318,14 @@ internal class ExposedSelektTest {
         val database = connect()
         transaction(database) {
             SchemaUtils.create(Users)
-            Users.insert { it[name] = "A"; it[email] = null }
-            Users.insert { it[name] = "B"; it[email] = null }
+            Users.insert {
+                it[name] = "A"
+                it[email] = null
+            }
+            Users.insert {
+                it[name] = "B"
+                it[email] = null
+            }
             Users.deleteWhere { Users.id greaterEq 1 }
             assertEquals(0L, Users.selectAll().count())
         }
@@ -329,7 +336,10 @@ internal class ExposedSelektTest {
         val database = connect()
         transaction(database) {
             SchemaUtils.create(Users)
-            Users.insert { it[name] = "Alice"; it[email] = "alice@example.com" }
+            Users.insert {
+                it[name] = "Alice"
+                it[email] = "alice@example.com"
+            }
             val names = Users.select(Users.name).map { it[Users.name] }
             assertEquals(listOf("Alice"), names)
         }
@@ -343,6 +353,148 @@ internal class ExposedSelektTest {
             val rows = Users.selectAll().toList()
             assertTrue(rows.isEmpty())
             assertEquals(0L, Users.selectAll().count())
+        }
+    }
+
+    @Test
+    fun readOnlyTransactionQuery() {
+        val database = connect()
+        transaction(database) {
+            SchemaUtils.create(Users)
+            Users.insert {
+                it[name] = "Alice"
+                it[email] = "alice@example.com"
+            }
+            Users.insert {
+                it[name] = "Bob"
+                it[email] = "bob@example.com"
+            }
+        }
+        transaction(
+            readOnly = true,
+            transactionIsolation = Connection.TRANSACTION_SERIALIZABLE,
+            db = database
+        ) {
+            val rows = Users.selectAll().toList()
+            assertEquals(2, rows.size)
+            assertEquals("Alice", rows[0][Users.name])
+            assertEquals("Bob", rows[1][Users.name])
+        }
+    }
+
+    @Test
+    fun readOnlyTransactionWithWhereClause() {
+        val database = connect()
+        transaction(database) {
+            SchemaUtils.create(Users)
+            Users.insert {
+                it[name] = "Alice"
+                it[email] = "alice@example.com"
+            }
+            Users.insert {
+                it[name] = "Bob"
+                it[email] = "bob@example.com"
+            }
+            Users.insert {
+                it[name] = "Charlie"
+                it[email] = "charlie@example.com"
+            }
+        }
+        transaction(
+            readOnly = true,
+            transactionIsolation = Connection.TRANSACTION_SERIALIZABLE,
+            db = database
+        ) {
+            val results = Users.selectAll().where { Users.name eq "Bob" }.toList()
+            assertEquals(1, results.size)
+            assertEquals("Bob", results.first()[Users.name])
+            assertEquals(3L, Users.selectAll().count())
+        }
+    }
+
+    @Test
+    fun multipleReadOnlyTransactions() {
+        val database = connect()
+        transaction(database) {
+            SchemaUtils.create(Users)
+            Users.insert {
+                it[name] = "Alice"
+                it[email] = null
+            }
+        }
+        transaction(
+            readOnly = true,
+            transactionIsolation = Connection.TRANSACTION_SERIALIZABLE,
+            db = database
+        ) {
+            assertEquals(1L, Users.selectAll().count())
+        }
+        transaction(database) {
+            Users.insert {
+                it[name] = "Bob"
+                it[email] = null
+            }
+        }
+        transaction(
+            readOnly = true,
+            transactionIsolation = Connection.TRANSACTION_SERIALIZABLE,
+            db = database
+        ) {
+            assertEquals(2L, Users.selectAll().count())
+        }
+    }
+
+    @Test
+    fun readOnlyTransactionBetweenWriteTransactions() {
+        val database = connect()
+        transaction(database) {
+            SchemaUtils.create(Users)
+            Users.insert { it[name] = "First"; it[email] = null }
+        }
+        transaction(
+            readOnly = true,
+            transactionIsolation = Connection.TRANSACTION_SERIALIZABLE,
+            db = database
+        ) {
+            val rows = Users.selectAll().toList()
+            assertEquals(1, rows.size)
+            assertEquals("First", rows.first()[Users.name])
+        }
+        transaction(database) {
+            Users.insert {
+                it[name] = "Second"
+                it[email] = null
+            }
+            assertEquals(2L, Users.selectAll().count())
+        }
+    }
+
+    @Test
+    fun readOnlyTransactionWithJoinedTables() {
+        val database = connect()
+        transaction(database) {
+            SchemaUtils.create(Users, Posts)
+            val authorId = Users.insert {
+                it[name] = "Author"
+                it[email] = null
+            }[Users.id]
+            Posts.insert {
+                it[title] = "Post Title"
+                it[body] = "Post Body"
+                it[Posts.authorId] = authorId
+            }
+        }
+        transaction(
+            readOnly = true,
+            transactionIsolation = Connection.TRANSACTION_SERIALIZABLE,
+            db = database
+        ) {
+            val posts = Posts.selectAll().toList()
+            assertEquals(1, posts.size)
+            assertEquals("Post Title", posts.first()[Posts.title])
+            val users = Users.selectAll().toList()
+            assertEquals(1, users.size)
+            assertEquals("Author", users.first()[Users.name])
         }
     }
 }


### PR DESCRIPTION
Read-only connections no longer open deferred transactions that pin WAL read marks and block FULL/TRUNCATE checkpoints. Queries now correctly execute without acquiring a write lock, allowing background reads to proceed while a write transaction is open on another thread.